### PR TITLE
Add youtube_dl to requirements

### DIFF
--- a/extensions/music/ytdlsource.py
+++ b/extensions/music/ytdlsource.py
@@ -26,8 +26,7 @@ class YTDLSource(discord.PCMVolumeTransformer):
         "logtostderr": False,
         "quiet": True,
         "no_warnings": True,
-        "default_search": "auto",
-        "source_address": "0.0.0.0",
+        "default_search": "auto"
     }
 
     FFMPEG_OPTIONS = {


### PR DESCRIPTION
Since bot's IP changes a lot right now and I am not experienced with YTDL IP binding, this option is removed.